### PR TITLE
Sync watch history from multiple tautulli libraries

### DIFF
--- a/apps/api/prisma/migrations/20230713021452_tautlli_library_ids/migration.sql
+++ b/apps/api/prisma/migrations/20230713021452_tautlli_library_ids/migration.sql
@@ -1,0 +1,54 @@
+-- RedefineTables
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE "new_Settings" (
+  "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  "radarrUrl" TEXT,
+  "radarrApiKey" TEXT,
+  "tautulliUrl" TEXT,
+  "tautulliApiKey" TEXT,
+  "tautlliLibraryIds" TEXT,
+  "enabled" BOOLEAN NOT NULL DEFAULT false,
+  "syncDays" INTEGER DEFAULT 1,
+  "syncHour" INTEGER DEFAULT 3,
+  "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" DATETIME NOT NULL
+);
+
+INSERT INTO
+  "new_Settings" (
+    "createdAt",
+    "enabled",
+    "id",
+    "radarrApiKey",
+    "radarrUrl",
+    "syncDays",
+    "syncHour",
+    "tautulliApiKey",
+    "tautulliUrl",
+    "tautlliLibraryIds",
+    "updatedAt"
+  )
+SELECT
+  "createdAt",
+  "enabled",
+  "id",
+  "radarrApiKey",
+  "radarrUrl",
+  "syncDays",
+  "syncHour",
+  "tautulliApiKey",
+  "tautulliUrl",
+  cast("tautlliLibraryId" as text) as "tautlliLibraryIds",
+  "updatedAt"
+FROM
+  "Settings";
+
+DROP TABLE "Settings";
+
+ALTER TABLE
+  "new_Settings" RENAME TO "Settings";
+
+PRAGMA foreign_key_check;
+
+PRAGMA foreign_keys = ON;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -49,17 +49,17 @@ model MovieTag {
 }
 
 model Settings {
-  id               Int      @id @default(autoincrement())
-  radarrUrl        String?
-  radarrApiKey     String?
-  tautulliUrl      String?
-  tautulliApiKey   String?
-  tautlliLibraryId Int?
-  enabled          Boolean  @default(false)
-  syncDays         Int?     @default(1)
-  syncHour         Int?     @default(3)
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  id                Int      @id @default(autoincrement())
+  radarrUrl         String?
+  radarrApiKey      String?
+  tautulliUrl       String?
+  tautulliApiKey    String?
+  tautlliLibraryIds String?
+  enabled           Boolean  @default(false)
+  syncDays          Int?     @default(1)
+  syncHour          Int?     @default(3)
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
 }
 
 model Rule {

--- a/apps/api/src/settings/settings.service.ts
+++ b/apps/api/src/settings/settings.service.ts
@@ -20,7 +20,7 @@ const radarrSettingsSelect: Prisma.SettingsSelect = {
 const tautulliSettingsSelect: Prisma.SettingsSelect = {
   tautulliUrl: true,
   tautulliApiKey: true,
-  tautlliLibraryId: true,
+  tautlliLibraryIds: true,
 }
 
 @Injectable()
@@ -38,6 +38,18 @@ export class SettingsService implements OnModuleInit {
       create: { id: this.id },
       update: {},
     })
+  }
+
+  // priv methods //
+
+  private serializeTautulliRecord(record): TautulliSettings {
+    const { tautulliUrl, tautulliApiKey, tautlliLibraryIds } = record
+
+    return {
+      tautulliUrl,
+      tautulliApiKey,
+      tautlliLibraryIds: tautlliLibraryIds?.split(',').map(Number) ?? [],
+    }
   }
 
   // public methods //
@@ -115,7 +127,11 @@ export class SettingsService implements OnModuleInit {
    */
   async getTautulli(): Promise<TautulliSettings> {
     try {
-      return this.findFirst<TautulliSettings>(tautulliSettingsSelect)
+      const record = await this.findFirst<TautulliSettings>(
+        tautulliSettingsSelect,
+      )
+
+      return this.serializeTautulliRecord(record)
     } catch (e) {
       const error = new Error(`Failed to get tautulli settings: ${e.message}`)
       this.logger.error(error.message)
@@ -129,8 +145,12 @@ export class SettingsService implements OnModuleInit {
    */
   async updateTautulli(settings: TautulliSettings): Promise<TautulliSettings> {
     try {
-      const { tautulliUrl, tautulliApiKey, tautlliLibraryId } = settings
-      const data = { tautulliUrl, tautulliApiKey, tautlliLibraryId }
+      const { tautulliUrl, tautulliApiKey, tautlliLibraryIds } = settings
+      const data = {
+        tautulliUrl,
+        tautulliApiKey,
+        tautlliLibraryIds: tautlliLibraryIds?.join(',') ?? undefined,
+      }
 
       return this.update<TautulliSettings>({
         update: data,

--- a/apps/api/src/tautulli/tautulli.service.ts
+++ b/apps/api/src/tautulli/tautulli.service.ts
@@ -165,6 +165,9 @@ export class TautulliService {
 
           if (mediaInfo) {
             matches.push(mediaInfo)
+
+            // break out of the loop if we found a match for this title
+            break
           }
         }
       }

--- a/apps/api/src/tautulli/tautulli.service.ts
+++ b/apps/api/src/tautulli/tautulli.service.ts
@@ -6,6 +6,7 @@ import type {
   TautulliMediaInfo,
   TautulliPing,
   TautulliSettings,
+  TautulliWatchHistory,
 } from '@usharr/types'
 import type { AxiosInstance } from 'axios'
 import axios from 'axios'
@@ -95,12 +96,13 @@ export class TautulliService {
   }
 
   /**
-   * Search Tautulli for media info for a given movie title (search string)
+   * Search Tautulli for media info for a given movie title (search string) and library (section_id)
    */
   async searchMediaInfoForTitle(
     title: string,
+    libraryId: number,
     tautulliSettings?: TautulliSettings,
-  ): Promise<TautulliMediaInfo | undefined> {
+  ): Promise<TautulliWatchHistory | undefined> {
     try {
       const client = await this.createClient(tautulliSettings)
       const response = await client.get<TautulliGetLibraryMediaInfoResponse>(
@@ -110,7 +112,7 @@ export class TautulliService {
             cmd: 'get_library_media_info',
             refresh: true,
             search: title,
-            section_id: (await this.settings.getTautulli())?.tautlliLibraryId,
+            section_id: libraryId,
             section_type: 'movie',
           },
         },
@@ -118,11 +120,17 @@ export class TautulliService {
 
       const items: TautulliMediaInfo[] =
         response.data?.response?.data?.data ?? []
+
       const match: TautulliMediaInfo = items.find(
         (item) => item.title === title,
       )
 
       return match
+        ? {
+            watched: match.play_count > 0,
+            lastWatchedAt: new Date(match.last_played * 1000),
+          }
+        : undefined
     } catch (e) {
       const error = new Error(
         `Failed to get media info for "${title}": ${e.message}`,
@@ -135,25 +143,33 @@ export class TautulliService {
 
   /**
    * Search Tautulli for media info for all movie titles
-   * Loops through all titles until a match is found
+   * Loops through all titles and libraries for matches
    */
-  async searchHistoryForAllMovieTitles(
+  async getWatchHistoryFromAllLibrariesForTitles(
     titles: string[],
     tautulliSettings?: TautulliSettings,
-  ): Promise<TautulliMediaInfo | undefined> {
+  ): Promise<TautulliWatchHistory[]> {
     try {
-      for await (const title of titles) {
-        const mediaInfo = await this.searchMediaInfoForTitle(
-          title,
-          tautulliSettings,
-        )
+      const matches: TautulliWatchHistory[] = []
 
-        if (mediaInfo) {
-          return mediaInfo
+      const { tautlliLibraryIds } =
+        tautulliSettings ?? (await this.settings.getTautulli())
+
+      for await (const libraryId of tautlliLibraryIds) {
+        for await (const title of titles) {
+          const mediaInfo = await this.searchMediaInfoForTitle(
+            title,
+            libraryId,
+            tautulliSettings,
+          )
+
+          if (mediaInfo) {
+            matches.push(mediaInfo)
+          }
         }
       }
 
-      return undefined
+      return matches
     } catch (e) {
       const error = new Error(
         `Failed to get media info for titles: ${e.message}`,

--- a/apps/client/src/components/form.tsx
+++ b/apps/client/src/components/form.tsx
@@ -247,7 +247,7 @@ export function MultipleSelect<T>({
   className,
   disabled = false,
   onChange,
-  options,
+  options = [],
   required = false,
   values = [],
 }: MultipleSelectProps<T>): JSX.Element {

--- a/apps/client/src/views/settings/radarr.tsx
+++ b/apps/client/src/views/settings/radarr.tsx
@@ -1,5 +1,5 @@
 import type { RadarrPing, RadarrSettings } from '@usharr/types'
-import React, { useState } from 'react'
+import React from 'react'
 
 import Alert from '../../components/alert'
 import Button from '../../components/button'
@@ -21,14 +21,12 @@ export default function Radarr(): JSX.Element {
   const { create: radarrSync } = useCreate('/api/sync/radarr')
   const [settings, setSettings] = useAsyncState<RadarrSettings>(settingsData)
   const [ping, setPing] = useAsyncState<RadarrPing>(pingData)
-  const [saveEnabled, setSaveEnabled] = useState<boolean>(false)
   const { addToast } = useToast()
 
   const handlePing = async () => {
     const pingResponse = await postPing(settings)
     setPing(pingResponse)
 
-    setSaveEnabled(Boolean(pingResponse?.success))
     addToast({
       message: pingResponse?.success
         ? 'Radarr connection established successfully'
@@ -45,7 +43,6 @@ export default function Radarr(): JSX.Element {
   }
 
   const setProperty = (property: string) => (value: any) => {
-    setSaveEnabled(false)
     setSettings({
       ...settings,
       [property]: value,
@@ -109,7 +106,12 @@ export default function Radarr(): JSX.Element {
             Test
           </Button>
           <Button
-            disabled={settingsLoading || pingLoading || !saveEnabled}
+            disabled={
+              settingsLoading ||
+              pingLoading ||
+              !settings?.radarrUrl ||
+              !settings?.radarrApiKey
+            }
             type="submit">
             Save
           </Button>

--- a/packages/types/settings.ts
+++ b/packages/types/settings.ts
@@ -12,7 +12,7 @@ export type RadarrSettings = {
 export type TautulliSettings = {
   tautulliUrl: string | null
   tautulliApiKey: string | null
-  tautlliLibraryId: number | null
+  tautlliLibraryIds: number[] | null
 }
 
 export type Settings = GeneralSettings & RadarrSettings & TautulliSettings

--- a/packages/types/tautulli.ts
+++ b/packages/types/tautulli.ts
@@ -14,6 +14,11 @@ export type TautulliMediaInfo = {
   play_count: number
 }
 
+export type TautulliWatchHistory = {
+  watched: boolean
+  lastWatchedAt: Date
+}
+
 export type TautulliGetLibraryNamesResponse = {
   response: {
     result: string


### PR DESCRIPTION
### Description

Add ability to sync watch history from multiple tautulli libraries. Media items will search every selected tautulli library for a title match. The watched status will be true if the movie was watched in any library, and last watched date will be the latest date found.

fixes https://github.com/nicholasodonnell/usharr/issues/13