### PR TITLE
Smaller posters

### DIFF
--- a/apps/api/src/sync/sync.service.ts
+++ b/apps/api/src/sync/sync.service.ts
@@ -175,9 +175,9 @@ export class SyncService {
             ? Math.floor(radarrMovie.ratings.rottenTomatoes.value)
             : null,
           appearsInList: importlistMoviesTmdbIds.includes(radarrMovie.tmdbId),
-          poster: radarrMovie.images?.find(
-            (image) => image.coverType === 'poster',
-          )?.remoteUrl,
+          poster: radarrMovie.images
+            ?.find((image) => image.coverType === 'poster')
+            ?.remoteUrl?.replace(/original/, 'w500'),
           tags: radarrMovie.tags?.map((tag) => ({ id: tag })) ?? [],
           title: radarrMovie.title,
           deletedAt: null,


### PR DESCRIPTION
### Description

No need to use the original sized poster. Use the `500px` variant instead.