### PR TITLE
Refactor how watch history is synced using Tautulli get_history api

### DIFF
--- a/apps/api/prisma/migrations/20240219032733_drop_tautlli_library_ids/migration.sql
+++ b/apps/api/prisma/migrations/20240219032733_drop_tautlli_library_ids/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `tautlliLibraryIds` on the `Settings` table. All the data in the column will be lost.
+
+*/
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Settings" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "radarrUrl" TEXT,
+    "radarrApiKey" TEXT,
+    "radarrAddImportListExclusion" BOOLEAN NOT NULL DEFAULT true,
+    "tautulliUrl" TEXT,
+    "tautulliApiKey" TEXT,
+    "enabled" BOOLEAN NOT NULL DEFAULT false,
+    "syncDays" INTEGER DEFAULT 1,
+    "syncHour" INTEGER DEFAULT 3,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_Settings" ("createdAt", "enabled", "id", "radarrAddImportListExclusion", "radarrApiKey", "radarrUrl", "syncDays", "syncHour", "tautulliApiKey", "tautulliUrl", "updatedAt") SELECT "createdAt", "enabled", "id", "radarrAddImportListExclusion", "radarrApiKey", "radarrUrl", "syncDays", "syncHour", "tautulliApiKey", "tautulliUrl", "updatedAt" FROM "Settings";
+DROP TABLE "Settings";
+ALTER TABLE "new_Settings" RENAME TO "Settings";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -55,7 +55,6 @@ model Settings {
   radarrAddImportListExclusion Boolean  @default(true)
   tautulliUrl                  String?
   tautulliApiKey               String?
-  tautlliLibraryIds            String?
   enabled                      Boolean  @default(false)
   syncDays                     Int?     @default(1)
   syncHour                     Int?     @default(3)

--- a/apps/api/src/settings/settings.model.ts
+++ b/apps/api/src/settings/settings.model.ts
@@ -52,12 +52,6 @@ export class Settings implements ISettings {
   syncHour: number
 
   @ApiProperty()
-  @IsArray()
-  @IsNumber({}, { each: true })
-  @IsOptional()
-  tautlliLibraryIds: null | number[]
-
-  @ApiProperty()
   @IsString()
   @IsOptional()
   tautulliApiKey: null | string
@@ -101,11 +95,7 @@ export class RadarrSettings
 }
 
 export class TautulliSettings
-  extends PickType(Settings, [
-    'tautlliLibraryIds',
-    'tautulliApiKey',
-    'tautulliUrl',
-  ])
+  extends PickType(Settings, ['tautulliApiKey', 'tautulliUrl'])
   implements ITautulliSettings
 {
   constructor(partial: Partial<TautulliSettings>) {

--- a/apps/api/src/settings/settings.service.ts
+++ b/apps/api/src/settings/settings.service.ts
@@ -29,7 +29,6 @@ export class SettingsService implements OnModuleInit {
     radarrUrl: true,
   }
   readonly tautulliSettingsSelect: Prisma.SettingsSelect = {
-    tautlliLibraryIds: true,
     tautulliApiKey: true,
     tautulliUrl: true,
   }
@@ -44,10 +43,9 @@ export class SettingsService implements OnModuleInit {
   }
 
   private serializeTautulliRecord(record): TautulliSettings {
-    const { tautlliLibraryIds, tautulliApiKey, tautulliUrl } = record
+    const { tautulliApiKey, tautulliUrl } = record
 
     return new TautulliSettings({
-      tautlliLibraryIds: tautlliLibraryIds?.split(',').map(Number) ?? [],
       tautulliApiKey,
       tautulliUrl,
     })
@@ -179,9 +177,8 @@ export class SettingsService implements OnModuleInit {
     settings: TautulliSettingsDTO,
   ): Promise<TautulliSettings> {
     try {
-      const { tautlliLibraryIds, tautulliApiKey, tautulliUrl } = settings
+      const { tautulliApiKey, tautulliUrl } = settings
       const data = {
-        tautlliLibraryIds: tautlliLibraryIds?.join(',') ?? undefined,
         tautulliApiKey,
         tautulliUrl,
       }

--- a/apps/api/src/sync/sync.service.ts
+++ b/apps/api/src/sync/sync.service.ts
@@ -7,11 +7,10 @@ import type {
   RadarrPing,
   RadarrTag,
   Rule,
-  Sync,
   SyncType,
   Tag,
+  TautulliHistory,
   TautulliPing,
-  TautulliWatchHistory,
 } from '@usharr/types'
 
 import { MovieService } from '../movie/movie.service'
@@ -20,6 +19,8 @@ import { RadarrService } from '../radarr/radarr.service'
 import { RuleService } from '../rule/rule.service'
 import { TagService } from '../tag/tag.service'
 import { TautulliService } from '../tautulli/tautulli.service'
+
+import { Sync } from './sync.model'
 
 const select: Prisma.SyncSelect = {
   finishedAt: true,
@@ -91,12 +92,12 @@ export class SyncService {
   private serializeRecord(record): Sync {
     const { finishedAt, id, startedAt, type } = record
 
-    return {
-      finishedAt: finishedAt ? new Date(startedAt) : null,
+    return new Sync({
+      finishedAt: finishedAt ? new Date(finishedAt) : null,
       id,
       startedAt: new Date(startedAt),
       type,
-    }
+    })
   }
 
   private async update(params: {
@@ -146,10 +147,12 @@ export class SyncService {
    */
   async finish(id: number): Promise<Sync> {
     try {
-      return await this.update({
+      const record = await this.update({
         data: { finishedAt: new Date() },
         where: { id },
       })
+
+      return this.serializeRecord(record)
     } catch (e) {
       const error = new Error(`Failed to finish sync: ${e.message}`)
       this.logger.error(error)
@@ -162,7 +165,7 @@ export class SyncService {
    * Performs a FULL sync:
    * - update all movies
    * - update all tags
-   * - update watch history
+   * - update watch history since the beginning of time
    * - delete movies for rules
    */
   async full(): Promise<void> {
@@ -193,13 +196,13 @@ export class SyncService {
   /**
    * Returns the last finished FULL sync
    */
-  async getLastFull(): Promise<Sync | null> {
+  async getLast(type?: SyncType): Promise<Sync | null> {
     try {
-      return this.findFirst({
+      return await this.findFirst({
         orderBy: { finishedAt: 'desc' },
         where: {
           finishedAt: { not: null },
-          type: SyncService.FULL,
+          ...(type ? { type } : {}),
         },
       })
     } catch (e) {
@@ -306,7 +309,7 @@ export class SyncService {
    * Performs a PARTIAL sync:
    * - update all movies
    * - update all tags
-   * - update watch history
+   * - update watch history since the last sync
    */
   async partial(): Promise<void> {
     let sync: Sync = null
@@ -315,9 +318,11 @@ export class SyncService {
       this.logger.log('Starting partial sync')
       sync = await this.start(SyncService.PARTIAL)
 
+      const lastSync: Sync | null = await this.getLast()
+
       await this.tags()
       await this.movies()
-      await this.watchHistory()
+      await this.watchHistory(lastSync?.finishedAt)
 
       this.logger.log('Finished partial sync')
     } catch (e) {
@@ -337,10 +342,12 @@ export class SyncService {
    */
   async start(type: SyncType): Promise<Sync> {
     try {
-      return await this.create({
+      const record = await this.create({
         startedAt: new Date(),
         type,
       })
+
+      return this.serializeRecord(record)
     } catch (e) {
       const error = new Error(`Failed to start sync: ${e.message}`)
       this.logger.error(error)
@@ -386,11 +393,7 @@ export class SyncService {
     }
   }
 
-  /**
-   * Sync the watch status of all non-deleted movies from Tautulli
-   * Syncing is done by searching the Tautulli history for the movie title(s)
-   */
-  async watchHistory(): Promise<void> {
+  async watchHistory(since: Date = new Date(0)): Promise<void> {
     try {
       const ping: TautulliPing = await this.tautulli.ping()
 
@@ -399,36 +402,25 @@ export class SyncService {
       }
 
       const moviesToSync: Movie[] = await this.movie.getNotDeleted()
+      const watchHistory: TautulliHistory[] = await this.tautulli.getHistory(
+        since,
+      )
 
-      for await (const movieToSync of moviesToSync) {
-        const watchHistory: TautulliWatchHistory[] =
-          await this.tautulli.getWatchHistoryFromAllLibrariesForTitles([
-            movieToSync.title,
-            ...movieToSync.alternativeTitles,
-          ])
+      for (const movie of moviesToSync) {
+        const titles = [movie.title, ...movie.alternativeTitles]
 
-        if (watchHistory.length === 0) {
-          this.logger.warn(`No watch history found for "${movieToSync.title}"`)
+        const history: TautulliHistory | undefined = watchHistory.find(
+          (history) => titles.includes(history.title),
+        )
 
+        if (!history) {
           continue
         }
 
-        const watched = watchHistory.some(
-          (item: TautulliWatchHistory) => item.watched,
-        )
-
-        const lastWatchedAt = watched
-          ? new Date(
-              Math.max(
-                ...watchHistory.map((item) => item.lastWatchedAt.getTime()),
-              ),
-            )
-          : null
-
-        const movie: Movie = await this.movie.createOrUpdate({
-          ...movieToSync,
-          lastWatchedAt,
-          watched,
+        await this.movie.createOrUpdate({
+          ...movie,
+          lastWatchedAt: history.date,
+          watched: true,
         })
 
         this.logger.log(`Synced watch history for "${movie.title}"`)

--- a/apps/api/src/sync/sync.service.ts
+++ b/apps/api/src/sync/sync.service.ts
@@ -175,9 +175,11 @@ export class SyncService {
       this.logger.log('Starting full sync')
       sync = await this.start(SyncService.FULL)
 
+      const lastSync: Sync | null = await this.getLast()
+
       await this.tags()
       await this.movies()
-      await this.watchHistory()
+      await this.watchHistory(lastSync?.finishedAt)
       await this.deleteMovies()
 
       this.logger.log('Finished full sync')

--- a/apps/api/src/task/task.service.ts
+++ b/apps/api/src/task/task.service.ts
@@ -26,7 +26,9 @@ export class TaskService {
       const { enabled, syncDays, syncHour }: GeneralSettings =
         await this.settings.getGeneral()
       const runningSyncs: Sync[] = await this.sync.getRunning()
-      const lastFullSync: Sync | null = await this.sync.getLastFull()
+      const lastFullSync: Sync | null = await this.sync.getLast(
+        SyncService.FULL,
+      )
       const now: Date = new Date()
 
       if (runningSyncs.length > 0) {

--- a/apps/api/src/tautulli/tautulli.model.ts
+++ b/apps/api/src/tautulli/tautulli.model.ts
@@ -1,39 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger'
-import type {
-  TautulliLibrary as ITautulliLibrary,
-  TautulliPing as ITautulliPing,
-} from '@usharr/types'
-import { Type } from 'class-transformer'
-import {
-  IsArray,
-  IsBoolean,
-  IsNotEmpty,
-  IsNumber,
-  IsOptional,
-  IsString,
-  ValidateNested,
-} from 'class-validator'
-
-export class TautulliLibrary implements ITautulliLibrary {
-  @ApiProperty()
-  @IsNotEmpty()
-  @IsNumber()
-  section_id: number
-
-  @ApiProperty()
-  @IsNotEmpty()
-  @IsString()
-  section_name: string
-}
+import type { TautulliPing as ITautulliPing } from '@usharr/types'
+import { IsBoolean } from 'class-validator'
 
 export class TautulliPing implements ITautulliPing {
-  @ApiProperty()
-  @IsArray()
-  @IsOptional()
-  @Type(() => TautulliLibrary)
-  @ValidateNested({ each: true })
-  libraries?: TautulliLibrary[]
-
   @ApiProperty()
   @IsBoolean()
   success: boolean

--- a/apps/api/src/tautulli/tautulli.service.ts
+++ b/apps/api/src/tautulli/tautulli.service.ts
@@ -1,11 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common'
 import type {
-  TautulliGetLibraryMediaInfoResponse,
-  TautulliGetLibraryNamesResponse,
-  TautulliLibrary,
-  TautulliMediaInfo,
+  TautulliGetHistoryResponse,
+  TautulliHistory,
   TautulliSettings,
-  TautulliWatchHistory,
 } from '@usharr/types'
 import type { AxiosInstance } from 'axios'
 import axios from 'axios'
@@ -33,76 +30,47 @@ export class TautulliService {
     })
   }
 
-  /**
-   * Get all libraries from Tautulli
-   */
-  async getLibraries(
+  async getHistory(
+    after: Date,
     tautulliSettings?: TautulliSettings,
-  ): Promise<TautulliLibrary[]> {
+  ): Promise<TautulliHistory[]> {
     try {
       const client = await this.createClient(tautulliSettings)
-
-      const response = await client.get<TautulliGetLibraryNamesResponse>(
-        '/api/v2',
-        {
-          params: {
-            cmd: 'get_library_names',
-          },
+      const response = await client.get<TautulliGetHistoryResponse>('/api/v2', {
+        params: {
+          after: after.toISOString().split('T')[0],
+          cmd: 'get_history',
+          length: 999999, // get all history
+          media_type: 'movie',
         },
-      )
+      })
 
-      return (
-        response.data?.response?.data
-          ?.filter((library) => library.section_type === 'movie')
-          ?.map((library) => ({
-            section_id: library.section_id,
-            section_name: library.section_name,
-          })) ?? []
-      )
-    } catch (e) {
-      const error = new Error(`Failed to retrieve library names: ${e.message}`)
-      this.logger.error(error.message)
+      const historyItems: Record<string, Date> = {}
 
-      throw error
-    }
-  }
+      for (const history of response?.data?.response?.data?.data ?? []) {
+        const { date, title, watched_status } = history
 
-  /**
-   * Search Tautulli for media info for all movie titles
-   * Loops through all titles and libraries for matches
-   */
-  async getWatchHistoryFromAllLibrariesForTitles(
-    titles: string[],
-    tautulliSettings?: TautulliSettings,
-  ): Promise<TautulliWatchHistory[]> {
-    try {
-      const matches: TautulliWatchHistory[] = []
-
-      const { tautlliLibraryIds } =
-        tautulliSettings ?? (await this.settings.getTautulli())
-
-      for await (const libraryId of tautlliLibraryIds) {
-        for await (const title of titles) {
-          const mediaInfo = await this.searchMediaInfoForTitle(
-            title,
-            libraryId,
-            tautulliSettings,
-          )
-
-          if (mediaInfo) {
-            matches.push(mediaInfo)
-
-            // break out of the loop if we found a match for this title
-            break
-          }
+        // movie must be watched at least 50% to be considered watched
+        if (watched_status < 0.5) {
+          continue
         }
+
+        // Only add the first watched item for each title because we only want to consider
+        // the latest watched date
+        if (historyItems[title]) {
+          continue
+        }
+
+        // Convert the date from seconds to milliseconds
+        historyItems[title] = new Date(date * 1000)
       }
 
-      return matches
+      return Object.entries(historyItems).map(([title, date]) => ({
+        date,
+        title,
+      }))
     } catch (e) {
-      const error = new Error(
-        `Failed to get media info for titles: ${e.message}`,
-      )
+      const error = new Error(`Failed to retrieve history: ${e.message}`)
       this.logger.error(error.message)
 
       throw error
@@ -123,7 +91,6 @@ export class TautulliService {
       })
 
       return new TautulliPing({
-        libraries: await this.getLibraries(tautulliSettings),
         success: response.status === 200,
       })
     } catch (e) {
@@ -131,52 +98,6 @@ export class TautulliService {
       this.logger.error(error.message)
 
       return { success: false }
-    }
-  }
-
-  /**
-   * Search Tautulli for media info for a given movie title (search string) and library (section_id)
-   */
-  async searchMediaInfoForTitle(
-    title: string,
-    libraryId: number,
-    tautulliSettings?: TautulliSettings,
-  ): Promise<TautulliWatchHistory | undefined> {
-    try {
-      const client = await this.createClient(tautulliSettings)
-      const response = await client.get<TautulliGetLibraryMediaInfoResponse>(
-        '/api/v2',
-        {
-          params: {
-            cmd: 'get_library_media_info',
-            refresh: true,
-            search: title,
-            section_id: libraryId,
-            section_type: 'movie',
-          },
-        },
-      )
-
-      const items: TautulliMediaInfo[] =
-        response.data?.response?.data?.data ?? []
-
-      const match: TautulliMediaInfo = items.find(
-        (item) => item.title === title,
-      )
-
-      return match
-        ? {
-            lastWatchedAt: new Date(match.last_played * 1000),
-            watched: match.play_count > 0,
-          }
-        : undefined
-    } catch (e) {
-      const error = new Error(
-        `Failed to get media info for "${title}": ${e.message}`,
-      )
-      this.logger.error(error.message)
-
-      throw error
     }
   }
 }

--- a/apps/client/src/views/settings/tautulli.tsx
+++ b/apps/client/src/views/settings/tautulli.tsx
@@ -7,14 +7,7 @@ import React from 'react'
 
 import Alert from '../../components/alert'
 import Button from '../../components/button'
-import {
-  Actions,
-  Field,
-  Form,
-  Input,
-  Label,
-  MultipleSelect,
-} from '../../components/form'
+import { Actions, Field, Form, Input, Label } from '../../components/form'
 import Section, { Title } from '../../components/section'
 import { useCreate, useFetch } from '../../hooks/useApi'
 import useAsyncState from '../../hooks/useAsyncState'
@@ -96,27 +89,6 @@ export default function Tautulli(): JSX.Element {
             value={settings?.tautulliApiKey}
           />
         </Field>
-        <Field>
-          <Label className="col-span-1" required>
-            Libraries
-          </Label>
-          <MultipleSelect<null | number>
-            className="col-span-3"
-            disabled={
-              settingsLoading ||
-              pingLoading ||
-              !ping?.libraries ||
-              ping?.libraries?.length === 0
-            }
-            onChange={setProperty('tautlliLibraryIds')}
-            options={ping?.libraries?.map(({ section_id, section_name }) => ({
-              label: section_name,
-              value: section_id,
-            }))}
-            required
-            values={settings?.tautlliLibraryIds}
-          />
-        </Field>
         <Actions>
           <Button
             disabled={settingsLoading || pingLoading}
@@ -129,8 +101,7 @@ export default function Tautulli(): JSX.Element {
               settingsLoading ||
               pingLoading ||
               !settings?.tautulliUrl ||
-              !settings?.tautulliApiKey ||
-              settings?.tautlliLibraryIds?.length < 1
+              !settings?.tautulliApiKey
             }
             type="submit">
             Save

--- a/packages/types/settings.ts
+++ b/packages/types/settings.ts
@@ -7,7 +7,6 @@ export type Settings = {
   radarrUrl: string | null
   syncDays: number
   syncHour: number
-  tautlliLibraryIds: number[] | null
   tautulliApiKey: string | null
   tautulliUrl: string | null
   updatedAt: Date
@@ -15,9 +14,9 @@ export type Settings = {
 
 export type GeneralSettings = Pick<Settings, 'enabled' | 'syncDays' | 'syncHour'>
 export type RadarrSettings = Pick<Settings, 'radarrApiKey' | 'radarrUrl' | 'radarrAddImportListExclusion'>
-export type TautulliSettings = Pick<Settings, 'tautlliLibraryIds' | 'tautulliApiKey' | 'tautulliUrl'>
+export type TautulliSettings = Pick<Settings, 'tautulliApiKey' | 'tautulliUrl'>
 
 export type SettingsDTO = Omit<Settings, 'id' | 'createdAt' | 'updatedAt'>
 export type GeneralSettingsDTO = Pick<SettingsDTO, 'enabled' | 'syncDays' | 'syncHour'>
 export type RadarrSettingsDTO = Pick<SettingsDTO, 'radarrApiKey' | 'radarrUrl' | 'radarrAddImportListExclusion'>
-export type TautulliSettingsDTO = Pick<SettingsDTO, 'tautlliLibraryIds' | 'tautulliApiKey' | 'tautulliUrl'>
+export type TautulliSettingsDTO = Pick<SettingsDTO, 'tautulliApiKey' | 'tautulliUrl'>

--- a/packages/types/tautulli.ts
+++ b/packages/types/tautulli.ts
@@ -1,51 +1,21 @@
 export type TautulliPing = {
   success: boolean
-  libraries?: TautulliLibrary[]
 }
 
-export type TautulliLibrary = {
-  section_id: number
-  section_name: string
-}
-
-export type TautulliMediaInfo = {
-  title: string
-  last_played: number
-  play_count: number
-}
-
-export type TautulliWatchHistory = {
-  watched: boolean
-  lastWatchedAt: Date
-}
-
-export type TautulliGetLibraryNamesResponse = {
+export type TautulliGetHistoryResponse = {
   response: {
-    result: string
-    message: string | null
     data: {
-      section_id: number
-      section_name: string
-      section_type: string
-      agent: string
-    }[]
-  }
-}
-
-export type TautulliGetLibraryMediaInfoResponse = {
-  response: {
-    result: string
-    message: string | null
-    data: {
-      recordsFiltered: number
-      recordsTotal: number
-      data: TautulliMediaInfo[]
+      data: {
+        date: number
+        watched_status: number
+        title: string
+      }[]
     }
   }
 }
 
-export type TautulliHistoryRecord = {
-  watched_status: number
+export type TautulliHistory = {
+  date: Date
   title: string
 }
 


### PR DESCRIPTION
### Description

Refactor how watch history is synced using the Tautulli `get_history` API. This API drastically reduces the complexity and time required to sync watch history into Usharr. Now, when a sync is performed only history since the previous sync date is fetched.

There is also no longer a need to select libraries when configuring Tautulli because the `get_history` API returns watch history for **all** libraries.

fix https://github.com/nicholasodonnell/usharr/issues/45