### PR TITLE
Improve how unmonitored movies are handled

### DIFF
--- a/apps/api/src/movie/movie.controller.ts
+++ b/apps/api/src/movie/movie.controller.ts
@@ -33,6 +33,12 @@ export class MovieController {
     return this.movie.getMonitored()
   }
 
+  @ApiOkResponse({ type: [Movie] })
+  @Get('unmonitored')
+  async getUnmonitored(): Promise<Movie[]> {
+    return this.movie.getUnmonitored()
+  }
+
   @ApiOkResponse({ type: Movie })
   @Put(':id')
   async update(

--- a/apps/api/src/movie/movie.model.ts
+++ b/apps/api/src/movie/movie.model.ts
@@ -33,7 +33,7 @@ export class Movie implements IMovie {
   @ApiProperty()
   @IsOptional()
   @IsNumber()
-  daysUntilDeletion: null | number
+  daysUntilDeletion: number | undefined
 
   @ApiProperty()
   @IsBoolean()
@@ -72,7 +72,7 @@ export class Movie implements IMovie {
   @Type(() => Rule)
   @IsOptional()
   @ValidateNested({ each: true })
-  matchedRule: Rule | null
+  matchedRule: Rule | undefined
 
   @ApiProperty()
   @IsNumber()

--- a/apps/api/src/rule/rule.service.ts
+++ b/apps/api/src/rule/rule.service.ts
@@ -244,7 +244,11 @@ export class RuleService {
    */
   async getAll(): Promise<Rule[]> {
     try {
-      return await this.findMany()
+      return await this.findMany({
+        orderBy: {
+          createdAt: 'asc',
+        },
+      })
     } catch (e) {
       const error = new Error(`Failed to get all rules: ${e.message}`)
       this.logger.error(error)
@@ -258,7 +262,12 @@ export class RuleService {
    */
   async getEnabled(): Promise<Rule[]> {
     try {
-      return await this.findMany({ where: { enabled: true } })
+      return await this.findMany({
+        orderBy: {
+          createdAt: 'asc',
+        },
+        where: { enabled: true },
+      })
     } catch (e) {
       const error = new Error(`Failed to get enabled rules: ${e.message}`)
       this.logger.error(error)

--- a/apps/api/src/sync/sync.service.ts
+++ b/apps/api/src/sync/sync.service.ts
@@ -165,8 +165,8 @@ export class SyncService {
    * Performs a FULL sync:
    * - update all movies
    * - update all tags
-   * - update watch history since the beginning of time
-   * - delete movies for rules
+   * - update watch history
+   * - delete movies
    */
   async full(): Promise<void> {
     let sync: Sync = null

--- a/apps/client/src/app.tsx
+++ b/apps/client/src/app.tsx
@@ -7,6 +7,7 @@ import Page from './views/_layout/page'
 import Deleted from './views/movies/deleted'
 import Ignored from './views/movies/ignored'
 import Monitored from './views/movies/monitored'
+import Unmonitored from './views/movies/unmonitored'
 import Rules from './views/rules'
 import General from './views/settings/general'
 import Radarr from './views/settings/radarr'
@@ -21,6 +22,7 @@ export default function App(): JSX.Element {
           <Route path="movies">
             <Route element={<Redirect to="/movies/monitored" />} index />
             <Route element={<Monitored />} path="monitored" />
+            <Route element={<Unmonitored />} path="unmonitored" />
             <Route element={<Ignored />} path="ignored" />
             <Route element={<Deleted />} path="deleted" />
           </Route>

--- a/apps/client/src/components/movieModal.tsx
+++ b/apps/client/src/components/movieModal.tsx
@@ -46,7 +46,7 @@ export default function MovieModal({
         <Form>
           {movie?.deleted && (
             <Alert className="mb-2" error>
-              Deleted On {new Date(movie.deletedAt).toLocaleDateString()}
+              Deleted {new Date(movie.deletedAt).toLocaleDateString()}
             </Alert>
           )}
           <div className="flex w-full flex-1 flex-row">
@@ -64,14 +64,14 @@ export default function MovieModal({
               </div>
               {movie.lastWatchedAt && (
                 <div className="grid grid-cols-2 gap-4">
-                  <P bold>Last Watched At</P>
+                  <P bold>Last Watched</P>
                   <P className="break-words">
                     {new Date(movie.lastWatchedAt).toLocaleDateString()}
                   </P>
                 </div>
               )}
               <div className="grid grid-cols-2 gap-4">
-                <P bold>Downloaded At</P>
+                <P bold>Downloaded</P>
                 <P className="break-words">
                   {new Date(movie.downloadedAt).toLocaleDateString()}
                 </P>
@@ -120,14 +120,15 @@ export default function MovieModal({
                   <P className="break-words">{movie.matchedRule.name}</P>
                 </div>
               )}
-              {movie.daysUntilDeletion && movie.daysUntilDeletion !== null && (
-                <div className="grid grid-cols-2 gap-4">
-                  <P bold>Time Remaining</P>
-                  <P bold className="break-words text-red">
-                    {movie.daysUntilDeletion} days
-                  </P>
-                </div>
-              )}
+              {!!movie.daysUntilDeletion &&
+                movie.daysUntilDeletion !== null && (
+                  <div className="grid grid-cols-2 gap-4">
+                    <P bold>Days Remaining</P>
+                    <P bold className="break-words text-red">
+                      {movie.daysUntilDeletion} days
+                    </P>
+                  </div>
+                )}
             </div>
           </div>
           <Actions>

--- a/apps/client/src/components/movies.tsx
+++ b/apps/client/src/components/movies.tsx
@@ -1,4 +1,5 @@
 import type { Movie as MovieModel } from '@usharr/types'
+import cx from 'classnames'
 import React, { useState } from 'react'
 
 import MovieModal from './movieModal'
@@ -10,11 +11,17 @@ export type MoviesProps = {
 
 export type MovieProps = {
   action?: string
+  className?: string
   movie: MovieModel
   onAction?: (movie: MovieModel) => Promise<void>
 }
 
-export function Movie({ action, movie, onAction }: MovieProps): JSX.Element {
+export function Movie({
+  action,
+  className,
+  movie,
+  onAction,
+}: MovieProps): JSX.Element {
   const [modalOpen, setModalOpen] = useState<boolean>(false)
 
   const handleAction = async (movie: MovieModel) => {
@@ -25,7 +32,10 @@ export function Movie({ action, movie, onAction }: MovieProps): JSX.Element {
   return (
     <div>
       <a
-        className="relative block w-full cursor-pointer overflow-hidden rounded-md border border-app-background-accent bg-app-background shadow transition-all hover:scale-105 hover:shadow-lg"
+        className={cx(
+          'relative block w-full cursor-pointer overflow-hidden rounded-md border border-app-background-accent bg-app-background shadow transition-all hover:scale-105 hover:shadow-lg',
+          className,
+        )}
         onClick={() => setModalOpen(true)}>
         <img
           alt={movie.title}
@@ -44,8 +54,14 @@ export function Movie({ action, movie, onAction }: MovieProps): JSX.Element {
         {movie.daysUntilDeletion !== null &&
           movie.daysUntilDeletion !== undefined && (
             <span className="font-small absolute left-2 top-2 z-30 rounded-lg border-[1px] border-app-background-accent bg-red p-1 text-sm uppercase text-white shadow-lg">
-              {movie.daysUntilDeletion} day
-              {movie.daysUntilDeletion !== 1 && 's'}
+              {movie.daysUntilDeletion > 0 ? (
+                <>
+                  {movie.daysUntilDeletion} day
+                  {movie.daysUntilDeletion !== 1 && 's'}
+                </>
+              ) : (
+                'Next Sync'
+              )}
             </span>
           )}
       </a>

--- a/apps/client/src/components/ruleModal.tsx
+++ b/apps/client/src/components/ruleModal.tsx
@@ -61,7 +61,7 @@ export default function RuleModal({
       <Section>
         <Title>{title}</Title>
         <Description>
-          Movies that match all these rules will be deleted.
+          Movies must match <strong>all</strong> rules.
         </Description>
         <Form onSubmit={handleSubmit}>
           <Field>

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -22,6 +22,12 @@ export const getMonitoredMovies = () =>
     url: '/api/movies/monitored',
   })
 
+export const getUnmonitoredMovies = () =>
+  request<Movie[]>({
+    method: 'GET',
+    url: '/api/movies/unmonitored',
+  })
+
 export const getDeletedMovies = () =>
   request<Movie[]>({
     method: 'GET',

--- a/apps/client/src/views/_layout/nav.tsx
+++ b/apps/client/src/views/_layout/nav.tsx
@@ -98,6 +98,7 @@ export default function Nav(): JSX.Element {
           <ul className="grid grid-cols-1 gap-6">
             <TopNav icon={<Movie />} title="Movies" to="/movies">
               <SubNav title="Monitored" to="/movies/monitored" />
+              <SubNav title="Unmonitored" to="/movies/unmonitored" />
               <SubNav title="Ignored" to="/movies/ignored" />
               <SubNav title="Deleted" to="/movies/deleted" />
             </TopNav>

--- a/apps/client/src/views/movies/ignored.tsx
+++ b/apps/client/src/views/movies/ignored.tsx
@@ -38,7 +38,7 @@ export default function Ignored(): JSX.Element {
 
   return (
     <Section>
-      <Title>Movies &#8212; Ignored</Title>
+      <Title>Ignored</Title>
       <Input
         className="mb-4 w-full"
         onChange={setSearch}

--- a/apps/client/src/views/movies/monitored.tsx
+++ b/apps/client/src/views/movies/monitored.tsx
@@ -1,4 +1,5 @@
 import type { Movie as MovieModel } from '@usharr/types'
+import cx from 'classnames'
 import React, { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from 'react-query'
 import { toast } from 'react-toastify'
@@ -6,6 +7,7 @@ import { toast } from 'react-toastify'
 import { Input } from '../../components/form'
 import Movies, { Movie } from '../../components/movies'
 import Section, { Title } from '../../components/section'
+import { H4 } from '../../components/text'
 import { getMonitoredMovies, updateMovie } from '../../lib/api'
 
 export default function Monitored(): JSX.Element {
@@ -29,31 +31,49 @@ export default function Monitored(): JSX.Element {
     await refetch()
   }
 
+  const moviesByMatchedRule = movies?.reduce<Record<string, MovieModel[]>>(
+    (acc, movie) => ({
+      ...acc,
+      [movie.matchedRule.name]: [...(acc[movie.matchedRule.name] || []), movie],
+    }),
+    {},
+  )
+
   return (
     <Section>
-      <Title>Movies &#8212; Monitored</Title>
+      <Title>Monitored</Title>
       <Input
         className="mb-4 w-full"
         onChange={setSearch}
         placeholder="Search"
         value={search}
       />
-      <Movies loading={isLoading}>
-        {movies
-          ?.filter((movie) =>
-            search
-              ? movie.title.toLowerCase().includes(search.toLowerCase())
-              : true,
-          )
-          ?.map((movie) => (
-            <Movie
-              action="Ignore"
-              key={movie.id}
-              movie={movie}
-              onAction={handleIgnore}
-            />
-          ))}
-      </Movies>
+      <div className="flex flex-col gap-12">
+        {Object.entries(moviesByMatchedRule || {}).map(([ruleName, movies]) => (
+          <div key={ruleName}>
+            <H4 className="mb-4">{ruleName}</H4>
+            <Movies loading={isLoading}>
+              {movies
+                ?.filter((movie) =>
+                  search
+                    ? movie.title.toLowerCase().includes(search.toLowerCase())
+                    : true,
+                )
+                ?.map((movie) => (
+                  <Movie
+                    action="Ignore"
+                    className={cx({
+                      'opacity-30': movie.daysUntilDeletion === null,
+                    })}
+                    key={movie.id}
+                    movie={movie}
+                    onAction={handleIgnore}
+                  />
+                ))}
+            </Movies>
+          </div>
+        ))}
+      </div>
     </Section>
   )
 }

--- a/apps/client/src/views/movies/unmonitored.tsx
+++ b/apps/client/src/views/movies/unmonitored.tsx
@@ -4,18 +4,18 @@ import { useQuery } from 'react-query'
 import { Input } from '../../components/form'
 import Movies, { Movie } from '../../components/movies'
 import Section, { Title } from '../../components/section'
-import { getDeletedMovies } from '../../lib/api'
+import { getUnmonitoredMovies } from '../../lib/api'
 
-export default function Deleted(): JSX.Element {
+export default function Unmonitored(): JSX.Element {
   const { data: movies, isLoading } = useQuery(
-    'movies/deleted',
-    getDeletedMovies,
+    'movies/unmonitored',
+    getUnmonitoredMovies,
   )
   const [search, setSearch] = useState<string>('')
 
   return (
     <Section>
-      <Title>Deleted</Title>
+      <Title>Unmonitored</Title>
       <Input
         className="mb-4 w-full"
         onChange={setSearch}


### PR DESCRIPTION
### Description

Improve how unmonitored moves are handled by:

- Add unmonitored movies tab
- Organize monitored movies by best matched rule
- Show soft matches in monitored section. Movies who do not match a dynamic rule (attributes that can change between syncs like rating, watch status, etc.) will appear faded out