### PR TITLE
Add option to treat soft matches as unmonitored

### DIFF
--- a/apps/api/prisma/migrations/20250204024315_treat_soft_match_as_unmonitored/migration.sql
+++ b/apps/api/prisma/migrations/20250204024315_treat_soft_match_as_unmonitored/migration.sql
@@ -1,0 +1,21 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Settings" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "radarrUrl" TEXT,
+    "radarrApiKey" TEXT,
+    "radarrAddImportListExclusion" BOOLEAN NOT NULL DEFAULT true,
+    "tautulliUrl" TEXT,
+    "tautulliApiKey" TEXT,
+    "enabled" BOOLEAN NOT NULL DEFAULT false,
+    "syncDays" INTEGER DEFAULT 1,
+    "syncHour" INTEGER DEFAULT 3,
+    "treatSoftMatchAsUnmonitored" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_Settings" ("createdAt", "enabled", "id", "radarrAddImportListExclusion", "radarrApiKey", "radarrUrl", "syncDays", "syncHour", "tautulliApiKey", "tautulliUrl", "updatedAt") SELECT "createdAt", "enabled", "id", "radarrAddImportListExclusion", "radarrApiKey", "radarrUrl", "syncDays", "syncHour", "tautulliApiKey", "tautulliUrl", "updatedAt" FROM "Settings";
+DROP TABLE "Settings";
+ALTER TABLE "new_Settings" RENAME TO "Settings";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -58,6 +58,7 @@ model Settings {
   enabled                      Boolean  @default(false)
   syncDays                     Int?     @default(1)
   syncHour                     Int?     @default(3)
+  treatSoftMatchAsUnmonitored  Boolean  @default(false)
   createdAt                    DateTime @default(now())
   updatedAt                    DateTime @updatedAt
 }

--- a/apps/api/src/movie/movie.module.ts
+++ b/apps/api/src/movie/movie.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 
 import { PrismaService } from '../prisma.service'
 import { RuleModule } from '../rule/rule.module'
+import { SettingsModule } from '../settings/settings.module'
 
 import { MovieController } from './movie.controller'
 import { MovieService } from './movie.service'
@@ -9,7 +10,7 @@ import { MovieService } from './movie.service'
 @Module({
   controllers: [MovieController],
   exports: [MovieService],
-  imports: [RuleModule],
+  imports: [RuleModule, SettingsModule],
   providers: [MovieService, PrismaService],
 })
 export class MovieModule {}

--- a/apps/api/src/settings/settings.model.ts
+++ b/apps/api/src/settings/settings.model.ts
@@ -61,6 +61,10 @@ export class Settings implements ISettings {
   tautulliUrl: null | string
 
   @ApiProperty()
+  @IsBoolean()
+  treatSoftMatchAsUnmonitored: boolean
+
+  @ApiProperty()
   @IsDate()
   updatedAt: Date
 
@@ -70,7 +74,12 @@ export class Settings implements ISettings {
 }
 
 export class GeneralSettings
-  extends PickType(Settings, ['enabled', 'syncDays', 'syncHour'])
+  extends PickType(Settings, [
+    'enabled',
+    'syncDays',
+    'syncHour',
+    'treatSoftMatchAsUnmonitored',
+  ])
   implements IGeneralSettings
 {
   constructor(partial: Partial<GeneralSettings>) {

--- a/apps/api/src/settings/settings.service.ts
+++ b/apps/api/src/settings/settings.service.ts
@@ -22,6 +22,7 @@ export class SettingsService implements OnModuleInit {
     enabled: true,
     syncDays: true,
     syncHour: true,
+    treatSoftMatchAsUnmonitored: true,
   }
   readonly radarrSettingsSelect: Prisma.SettingsSelect = {
     radarrAddImportListExclusion: true,
@@ -131,8 +132,9 @@ export class SettingsService implements OnModuleInit {
    */
   async updateGeneral(settings: GeneralSettingsDTO): Promise<GeneralSettings> {
     try {
-      const { enabled, syncDays, syncHour } = settings
-      const data = { enabled, syncDays, syncHour }
+      const { enabled, syncDays, syncHour, treatSoftMatchAsUnmonitored } =
+        settings
+      const data = { enabled, syncDays, syncHour, treatSoftMatchAsUnmonitored }
 
       const record = await this.update<GeneralSettings>({
         select: this.generalSettingsSelect,

--- a/apps/client/src/components/form.tsx
+++ b/apps/client/src/components/form.tsx
@@ -45,6 +45,11 @@ export type LabelPros = {
   required?: boolean
 }
 
+export type HintProps = {
+  children: React.ReactNode
+  className?: string
+}
+
 export type SelectOption<T> = {
   label: string
   value: T
@@ -131,6 +136,12 @@ export function Label({
         {required && <sup className="ml-1 text-red ">*</sup>}
       </span>
     </label>
+  )
+}
+
+export function Hint({ children, className }: HintProps): JSX.Element {
+  return (
+    <div className={cx('text-xs italic text-gray', className)}>{children}</div>
   )
 }
 

--- a/apps/client/src/views/settings/general.tsx
+++ b/apps/client/src/views/settings/general.tsx
@@ -8,6 +8,7 @@ import {
   Checkbox,
   Field,
   Form,
+  Hint,
   Label,
   NumberInput,
   Select,
@@ -100,6 +101,22 @@ export default function General(): JSX.Element {
             ]}
             required
             value={settings?.syncHour}
+          />
+        </Field>
+        <Field>
+          <Label className="col-span-1">
+            Treat soft matches as unmonitored
+            <Hint className="mt-2">
+              Soft matches are movies that match a rule but cannot be given a
+              deletion date because of dynamic conditions such as watch status,
+              rating, etc.?
+            </Hint>
+          </Label>
+          <Checkbox
+            className="col-span-3"
+            disabled={isLoading}
+            onChange={setProperty('treatSoftMatchAsUnmonitored')}
+            value={settings?.treatSoftMatchAsUnmonitored}
           />
         </Field>
         <Actions>

--- a/packages/types/settings.ts
+++ b/packages/types/settings.ts
@@ -9,10 +9,11 @@ export type Settings = {
   syncHour: number
   tautulliApiKey: string | null
   tautulliUrl: string | null
+  treatSoftMatchAsUnmonitored: boolean
   updatedAt: Date
 }
 
-export type GeneralSettings = Pick<Settings, 'enabled' | 'syncDays' | 'syncHour'>
+export type GeneralSettings = Pick<Settings, 'enabled' | 'syncDays' | 'syncHour' | 'treatSoftMatchAsUnmonitored'>
 export type RadarrSettings = Pick<Settings, 'radarrApiKey' | 'radarrUrl' | 'radarrAddImportListExclusion'>
 export type TautulliSettings = Pick<Settings, 'tautulliApiKey' | 'tautulliUrl'>
 


### PR DESCRIPTION
closes https://github.com/nicholasodonnell/usharr/issues/65

### Description

Introduces a setting to treat soft matches as unmonitored. Soft matches are movies that match a rule but are not eligible for deletion (or a countdown) because a dynamic rule such as rating, watch status, list inclusion is keeping it around.